### PR TITLE
Handle sigterm / Control+C gracefully

### DIFF
--- a/pgsanity/pgsanity.py
+++ b/pgsanity/pgsanity.py
@@ -69,4 +69,7 @@ def main():
     return check_files(config.files)
 
 if __name__ == '__main__':
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
Don't show the user a stack trace when he presses Control+C to stop pgsanity.
