### PR TITLE
Merge for tweaks that address BOM-table problems and step over psql-commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ errors of the SQL.
     - arch: sudo pacman -S postgresql-libs
 
 ###Getting PgSanity
-PgSanity is available in the Python Package Index, so you can install it with either easy_install or pip.  Here's [PgSanity's page on PyPI](http://pypi.python.org/pypi/pgsanity).
-- sudo pip install pgsanity **or** sudo easy_install pgsanity
+PgSanity is available in the Python Package Index, so you can install it with either easy\_install or pip.  Here's [PgSanity's page on PyPI](http://pypi.python.org/pypi/pgsanity).
+- sudo pip install pgsanity **or** sudo easy\_install pgsanity
     - If you don't have pip you can get it on ubuntu/debian by running: sudo apt-get install python-pip
 
 ##Usage

--- a/pgsanity/pgsanity.py
+++ b/pgsanity/pgsanity.py
@@ -44,17 +44,16 @@ def check_file(filename=None, show_filename=False):
     # either work with sys.stdin or open the file
     if filename is not None:
         with open(filename, "rb") as filelike:
-            # discard BOM if present then read remaining bytes
-            nose = filelike.read(len(BOM_UTF8))
-            nose = '' if check_for_bom(nose) else nose
-            sql_string = nose + filelike.read()
-            sql_string = sql_string.decode("utf-8")
-            # ^ This is safe for both ASCII and UTF-8 files.
+            sql_string = filelike.read()
     else:
         with sys.stdin as filelike:
             sql_string = sys.stdin.read()
-
-    success, msg = check_string(sql_string)
+    # check for BOM-table and discard if present
+    nose = sql_string[0:len(BOM_UTF8)]
+    bom_present = check_for_bom(nose)
+    sql_string = sql_string[len(nose):] if bom_present else sql_string
+    success, msg = check_string(sql_string.decode("utf-8"))
+    # ^ The above called to decode() is safe for both ASCII and UTF-8 data.
 
     # report results
     result = 0

--- a/pgsanity/pgsanity.py
+++ b/pgsanity/pgsanity.py
@@ -2,6 +2,8 @@
 
 from __future__ import print_function
 from __future__ import absolute_import
+from chardet import detect
+from codecs import BOM_UTF8
 import argparse
 import sys
 
@@ -13,6 +15,25 @@ def get_config(argv=sys.argv[1:]):
     parser.add_argument('files', nargs='*', default=None)
     return parser.parse_args(argv)
 
+def check_for_bom(starting_bytes):
+    """ Check the first few bytes of a file to determine whether input
+    contains a BOM-table or not.
+
+    Returns a boolean indicating whether a BOM-table appears to be present.
+    """
+    minlen = len(BOM_UTF8)
+    if len(starting_bytes) < minlen:
+        raise ValueError("Starting bytes of file must be at least"
+                         " {} bytes long to check for BOM.".format(minlen))
+    encoding = detect(starting_bytes)["encoding"]
+    is_utf8 = encoding in ["UTF-8","UTF-8-SIG"]
+    return is_utf8 and starting_bytes.startswith(BOM_UTF8)
+    # ^ The above is a tiny bit redundant given that 'UTF-8-SIG' simply means
+    # "UTF-8 file with a BOM-table". However, older versions of chardet don't
+    # support this, and will just detect 'UTF-8', leaving us to check for the
+    # BOM ourselves as we do above. The extra check is not harmful on
+    # systems that have a more recent chardet module.
+
 def check_file(filename=None, show_filename=False):
     """
     Check whether an input file is valid PostgreSQL. If no filename is
@@ -22,8 +43,13 @@ def check_file(filename=None, show_filename=False):
     """
     # either work with sys.stdin or open the file
     if filename is not None:
-        with open(filename, "r") as filelike:
-            sql_string = filelike.read()
+        with open(filename, "rb") as filelike:
+            # discard BOM if present then read remaining bytes
+            nose = filelike.read(len(BOM_UTF8))
+            nose = '' if check_for_bom(nose) else nose
+            sql_string = nose + filelike.read()
+            sql_string = sql_string.decode("utf-8")
+            # ^ This is safe for both ASCII and UTF-8 files.
     else:
         with sys.stdin as filelike:
             sql_string = sys.stdin.read()

--- a/pgsanity/pgsanity.py
+++ b/pgsanity/pgsanity.py
@@ -43,7 +43,7 @@ def check_file(filename=None, show_filename=False):
     """
     # either work with sys.stdin or open the file
     if filename is not None:
-        with open(filename, "rb") as filelike:
+        with open(filename, "r") as filelike:
             sql_string = filelike.read()
     else:
         with sys.stdin as filelike:
@@ -53,7 +53,7 @@ def check_file(filename=None, show_filename=False):
     bom_present = check_for_bom(nose)
     sql_string = sql_string[len(nose):] if bom_present else sql_string
     success, msg = check_string(sql_string.decode("utf-8"))
-    # ^ The above called to decode() is safe for both ASCII and UTF-8 data.
+    # ^ The above call to decode() is safe for both ASCII and UTF-8 data.
 
     # report results
     result = 0

--- a/pgsanity/sqlprep.py
+++ b/pgsanity/sqlprep.py
@@ -24,7 +24,7 @@ def prepare_sql(sql):
 
         if start == "/*":
             in_block_comment = True
-        elif start in ["--","\\"] and not in_block_comment:
+        elif start in ["--","\n\\"] and not in_block_comment:
             in_line_comment = True
             if not in_statement:
                 start_str = "//"
@@ -50,7 +50,7 @@ def split_sql(sql):
     """generate hunks of SQL that are between the bookends
        return: tuple of beginning bookend, closing bookend, and contents
          note: beginning & end of string are returned as None"""
-    bookends = ("\n", ";", "--", "/*", "*/", "\\")
+    bookends = ("\n\\","\n", ";", "--", "/*", "*/")
     last_bookend_found = None
     start = 0
 

--- a/pgsanity/sqlprep.py
+++ b/pgsanity/sqlprep.py
@@ -17,7 +17,7 @@ def prepare_sql(sql):
         # decide where we are
         if not in_statement and not in_line_comment and not in_block_comment:
             # not currently in any block
-            if start != "--" and start != "/*" and len(contents.strip()) > 0:
+            if start not in ["--","\n\\"] and start != "/*" and len(contents.strip()) > 0:
                 # not starting a comment and there is contents
                 in_statement = True
                 precontents = "EXEC SQL "

--- a/pgsanity/sqlprep.py
+++ b/pgsanity/sqlprep.py
@@ -17,14 +17,14 @@ def prepare_sql(sql):
         # decide where we are
         if not in_statement and not in_line_comment and not in_block_comment:
             # not currently in any block
-            if start not in ["--","\n\\","\\"] and start != "/*" and len(contents.strip()) > 0:
+            if start not in ["--","\\"] and start != "/*" and len(contents.strip()) > 0:
                 # not starting a comment and there is contents
                 in_statement = True
                 precontents = "EXEC SQL "
 
         if start == "/*":
             in_block_comment = True
-        elif start in ["--","\n\\","\\"] and not in_block_comment:
+        elif start in ["--","\\"] and not in_block_comment:
             in_line_comment = True
             if not in_statement:
                 start_str = "//"
@@ -50,7 +50,7 @@ def split_sql(sql):
     """generate hunks of SQL that are between the bookends
        return: tuple of beginning bookend, closing bookend, and contents
          note: beginning & end of string are returned as None"""
-    bookends = ("\n\\","\n", ";", "--", "/*", "*/","\\")
+    bookends = ("\n", ";", "--", "/*", "*/","\\")
     last_bookend_found = None
     start = 0
 

--- a/pgsanity/sqlprep.py
+++ b/pgsanity/sqlprep.py
@@ -17,14 +17,14 @@ def prepare_sql(sql):
         # decide where we are
         if not in_statement and not in_line_comment and not in_block_comment:
             # not currently in any block
-            if start not in ["--","\n\\"] and start != "/*" and len(contents.strip()) > 0:
+            if start not in ["--","\n\\","\\"] and start != "/*" and len(contents.strip()) > 0:
                 # not starting a comment and there is contents
                 in_statement = True
                 precontents = "EXEC SQL "
 
         if start == "/*":
             in_block_comment = True
-        elif start in ["--","\n\\"] and not in_block_comment:
+        elif start in ["--","\n\\","\\"] and not in_block_comment:
             in_line_comment = True
             if not in_statement:
                 start_str = "//"
@@ -50,7 +50,7 @@ def split_sql(sql):
     """generate hunks of SQL that are between the bookends
        return: tuple of beginning bookend, closing bookend, and contents
          note: beginning & end of string are returned as None"""
-    bookends = ("\n\\","\n", ";", "--", "/*", "*/")
+    bookends = ("\n\\","\n", ";", "--", "/*", "*/","\\")
     last_bookend_found = None
     start = 0
 

--- a/pgsanity/sqlprep.py
+++ b/pgsanity/sqlprep.py
@@ -24,7 +24,7 @@ def prepare_sql(sql):
 
         if start == "/*":
             in_block_comment = True
-        elif start in ["--","\n\\"] and not in_block_comment:
+        elif start in ["--","\\"] and not in_block_comment:
             in_line_comment = True
             if not in_statement:
                 start_str = "//"
@@ -50,7 +50,7 @@ def split_sql(sql):
     """generate hunks of SQL that are between the bookends
        return: tuple of beginning bookend, closing bookend, and contents
          note: beginning & end of string are returned as None"""
-    bookends = ("\n", ";", "--", "/*", "*/", "\n\\")
+    bookends = ("\n", ";", "--", "/*", "*/", "\\")
     last_bookend_found = None
     start = 0
 

--- a/pgsanity/sqlprep.py
+++ b/pgsanity/sqlprep.py
@@ -24,7 +24,7 @@ def prepare_sql(sql):
 
         if start == "/*":
             in_block_comment = True
-        elif start == "--" and not in_block_comment:
+        elif start in ["--","\n\\"] and not in_block_comment:
             in_line_comment = True
             if not in_statement:
                 start_str = "//"
@@ -50,7 +50,7 @@ def split_sql(sql):
     """generate hunks of SQL that are between the bookends
        return: tuple of beginning bookend, closing bookend, and contents
          note: beginning & end of string are returned as None"""
-    bookends = ("\n", ";", "--", "/*", "*/")
+    bookends = ("\n", ";", "--", "/*", "*/", "\n\\")
     last_bookend_found = None
     start = 0
 


### PR DESCRIPTION
I made some fairly minor alterations in the interest of making pgsanity easier to use. Changes include addressing #5 for both piped and file-based input, plus an edit which allows pgsanity to deal with `psql`-directives that might show up in incoming data. If the latter is not desired (at least as the default behavior), I can either move those changes over to a separate branch and then submit another pull-request once I've done so, or we could allow a flag to be passed that would prompt the ignore-psql-directives behavior.