### PR TITLE
Add "add-semicolon" flag to allow a missing final semicolon

### DIFF
--- a/pgsanity/sqlprep.py
+++ b/pgsanity/sqlprep.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     from io import StringIO
 
-def prepare_sql(sql):
+def prepare_sql(sql, add_semicolon=False):
     results = StringIO()
 
     in_statement = False
@@ -44,6 +44,10 @@ def prepare_sql(sql):
 
     response = results.getvalue()
     results.close()
+    if add_semicolon and in_statement and not in_block_comment:
+        if in_line_comment:
+            response = response + "\n"
+        response = response + ';'
     return response
 
 def split_sql(sql):

--- a/test/test_pgsanity.py
+++ b/test/test_pgsanity.py
@@ -9,11 +9,19 @@ class TestPgSanity(unittest.TestCase):
         args = ["myfile.sql"]
         config = pgsanity.get_config(args)
         self.assertEqual(args, config.files)
+        self.assertEqual(False, config.add_semicolon)
 
     def test_args_parsed_multiple_filenames(self):
         args = ["myfile.sql", "myotherfile.sql"]
         config = pgsanity.get_config(args)
         self.assertEqual(args, config.files)
+        self.assertEqual(False, config.add_semicolon)
+
+    def test_args_parsed_add_semicolon(self):
+        args = ["--add-semicolon", "myfile.sql"]
+        config = pgsanity.get_config(args)
+        self.assertEqual(["myfile.sql"], config.files)
+        self.assertEqual(True, config.add_semicolon)
 
     def test_check_valid_string(self):
         text = "select a from b;"
@@ -46,6 +54,20 @@ class TestPgSanityFiles(unittest.TestCase):
         write_out(self.file, text.encode('utf-8'))
         status_code = pgsanity.check_file(self.file.name)
         self.assertNotEqual(status_code, 0)
+
+    def _write_missing_semi(self):
+        text = "select a from b"
+        write_out(self.file, text.encode('utf-8'))
+
+    def test_check_missing_semi(self):
+        self._write_missing_semi()
+        status_code = pgsanity.check_file(self.file.name)
+        self.assertNotEqual(status_code, 0)
+
+    def test_check_missing_semi_ok(self):
+        self._write_missing_semi()
+        status_code = pgsanity.check_file(self.file.name, add_semicolon=True)
+        self.assertEqual(status_code, 0)
 
 
 def write_out(f, text):

--- a/test/test_sqlprep.py
+++ b/test/test_sqlprep.py
@@ -110,6 +110,31 @@ class TestSqlPrep(unittest.TestCase):
         expected = "EXEC SQL select a from b;EXEC SQL  select a\nfrom b;"
         self.assertEqual(expected, sqlprep.prepare_sql(text))
 
+    def test_no_append_semi(self):
+        text = "select a from b"
+        expected = 'EXEC SQL ' + text
+        self.assertEqual(expected, sqlprep.prepare_sql(text))
+
+    def test_append_semi(self):
+        text = "select a from b"
+        expected = 'EXEC SQL ' + text + ';'
+        self.assertEqual(expected, sqlprep.prepare_sql(text, add_semicolon=True))
+
+    def test_append_semi_once(self):
+        text = "select a from b;"
+        expected = 'EXEC SQL ' + text
+        self.assertEqual(expected, sqlprep.prepare_sql(text, add_semicolon=True))
+
+    def test_append_semi_line_comment(self):
+        text = "select a from b\n-- looks done!"
+        expected = 'EXEC SQL ' + text + "\n;"
+        self.assertEqual(expected, sqlprep.prepare_sql(text, add_semicolon=True))
+
+    def test_append_semi_line_comment(self):
+        text = "select a from b\n/* looks done!\n*"
+        expected = 'EXEC SQL ' + text
+        self.assertEqual(expected, sqlprep.prepare_sql(text, add_semicolon=True))
+
     def test_comment_start_found_within_comment_within_statement(self):
         text = "select a from b --comment in comment --here\nwhere c=1;"
         expected = "EXEC SQL select a from b --comment in comment --here\nwhere c=1;"


### PR DESCRIPTION
My SQL files are all used as input to programmatic SQL. When you use most (all?) PG client libraries, you don't need to provide the semicolon because the interface only allows you to send a single statement. Similarly, `psql -c 'select a from b'` works. In these cases, I don't want an error about a missing semicolon at the end.

This PR adds a `--add-semicolon` flag. When it's passed

* If you have a final semicolon already, nothing's changed
* If you end inside a block comment, nothing's changed (the code is invalid, but adding a semicolon can't help)
* If you end with a line comment, I add a newline + semicolon
* Otherwise I add a semicolon

I wrote some tests for the new behavior (which is pretty simple, I think). I'd be happy to make other modifications or add more tests if you'd like.