### PR TITLE
pgsanity.py fix for add_semicolon is not defined

### DIFF
--- a/pgsanity/pgsanity.py
+++ b/pgsanity/pgsanity.py
@@ -68,7 +68,8 @@ def check_files(files, add_semicolon=False):
 
 def main():
     config = get_config()
-    return check_files(config.files, add_semicolon=add_semicolon)
+    # return check_files(config.files, add_semicolon=add_semicolon)
+    return check_files(config.files)
 
 if __name__ == '__main__':
     try:

--- a/pgsanity/pgsanity.py
+++ b/pgsanity/pgsanity.py
@@ -68,8 +68,7 @@ def check_files(files, add_semicolon=False):
 
 def main():
     config = get_config()
-    # return check_files(config.files, add_semicolon=add_semicolon)
-    return check_files(config.files)
+    return check_files(config.files, add_semicolon=config.add_semicolon)
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
Now uses default add_semicolon parameter by not defining it.

This fix prevents the following issue.

```
$ pgsanity
Traceback (most recent call last):
  File "/usr/bin/pgsanity", line 11, in <module>
    load_entry_point('pgsanity==0.2.8', 'console_scripts', 'pgsanity')()
  File "build/bdist.cygwin-2.6.0-x86_64/egg/pgsanity/pgsanity.py", line 71, in main
NameError: global name 'add_semicolon' is not defined
```
