### PR TITLE
Dockerfile to run pgsanity as a container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.5-alpine
 
 RUN apk add --no-cache postgresql-dev
-RUN pip install pgsanity==0.2.9
+RUN pip install pgsanity
 
 ENTRYPOINT ["/usr/local/bin/pgsanity"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.5-alpine
+
+RUN apk add --no-cache postgresql-dev
+RUN pip install pgsanity==0.2.9
+
+ENTRYPOINT ["/usr/local/bin/pgsanity"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,5 +13,4 @@ This is a simple example of checking files in the current directory:
 docker run --rm -it -v $PWD:/host -w /host pgsanity file1.sql file2.sql
 ```
 
-More information on its
-[Github repository](https://github.com/markdrago/pgsanity).
+More information on its [Github repository](https://github.com/markdrago/pgsanity).

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,17 @@
+# PgSanity
+
+PgSanity checks the syntax of Postgresql SQL files.
+
+This Dockerfile is based on Alpine linux and generates images with approximately
+110MB.
+
+## Usage
+
+This is a simple example of checking files in the current directory:
+
+```bash
+docker run --rm -it -v $PWD:/host -w /host pgsanity file1.sql file2.sql
+```
+
+More information on its
+[Github repository](https://github.com/markdrago/pgsanity).


### PR DESCRIPTION
This PR adds a Dockerfile to execute **pgsanity** as a Docker container. I have also added [a repository](https://hub.docker.com/r/boechat107/pgsanity) on Docker Hub for automated builds (it might be a better idea to have an official one).

I find this useful for CIs.